### PR TITLE
use the same name for the closeView javascript object as for ios SDK,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ repositories {
 Add a dependency to your build.gradle file:
 
 ```
-implementation 'com.adnuntius.android.sdk:1.4.1'
+implementation 'com.adnuntius.android.sdk:1.4.2'
 ```
 
 ## Ad Delivery
@@ -80,8 +80,8 @@ Its now possible to close a web view from an adnuntius layout via javascript.
 If you want to be able to close ad view from javascript, its not possible to close the parent window from a layout due to the dreaded `Scripts may close only the windows that were opened by them.`   So we have added a new method you can call from javascript which provides this functionality:
 
 ```javascript
-if (typeof parent.androidAdnuntius != "undefined") {
- parent.androidAdnuntius.closeView();
+if (typeof parent.adnSdkHandler != "undefined") {
+ parent.adnSdkHandler.closeView();
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,12 @@
 buildscript {
-    ext.kotlin_version = "1.4.32"
+    ext.kotlin_version = "1.5.21"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.0"
+        classpath "com.android.tools.build:gradle:4.2.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        modules {
-            module("org.jetbrains.trove4j:trove4j") {
-                replacedBy("org.jetbrains.intellij.deps:trove4j")
-            }
-        }
     }
 }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-version = "1.4.1"
+version = "1.4.2"
 
 android {
     compileSdkVersion 29
@@ -113,14 +113,14 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'androidx.test:core:1.3.0'
+    testImplementation 'androidx.test:core:1.4.0'
     testImplementation "org.robolectric:robolectric:4.5.1"
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation "org.mockito:mockito-core:3.9.0"
+    testImplementation "org.mockito:mockito-core:3.11.0"
     testImplementation "net.javacrumbs.json-unit:json-unit:2.25.0"
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 }

--- a/sdk/src/main/java/com/adnuntius/android/sdk/AdnuntiusAdWebView.java
+++ b/sdk/src/main/java/com/adnuntius/android/sdk/AdnuntiusAdWebView.java
@@ -43,6 +43,9 @@ public class AdnuntiusAdWebView extends WebView {
         this.addJavascriptInterface(new InternalAdnuntiusJavascriptCallback(env, wrapper), "intAndroidAdnuntius");
         this.addJavascriptInterface(new AdnuntiusJavascriptCallback(wrapper), "androidAdnuntius");
 
+        // make the name compatible with the iOS sdk
+        this.addJavascriptInterface(new AdnuntiusJavascriptCallback(wrapper), "adnSdkHandler");
+
         // https://stackoverflow.com/a/23844693
         boolean isDebuggable = ( 0 != ( context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE ) );
         if (isDebuggable) {


### PR DESCRIPTION
… leave the androidAdnuntius for compatibility reasons